### PR TITLE
chore(changeset): trigger @clinwise/release-scribe 0.1.1 release test

### DIFF
--- a/.changeset/neat-steaks-invite.md
+++ b/.changeset/neat-steaks-invite.md
@@ -1,0 +1,6 @@
+---
+"@clinwise/release-scribe": patch
+---
+
+Trigger a follow-up patch release for `@clinwise/release-scribe` so the template can
+re-run the full changesets flow after the repository release finalization fix.


### PR DESCRIPTION
## Summary
- add a patch changeset for `@clinwise/release-scribe`
- trigger a fresh `version packages` PR after the repository release finalization fix
- validate that the workflow now publishes the package and also updates the repository release

## Expected result
- merging this PR should cause `changesets/action` to open a new `version packages` PR
- that version PR should bump `@clinwise/release-scribe` from `0.1.0` to `0.1.1`
- merging the version PR should publish the package and create the matching repository release

## Validation
- `pnpm exec changeset status --output=/tmp/release-scribe-status.json`
- confirmed release plan: `@clinwise/release-scribe 0.1.0 -> 0.1.1`
