### PR TITLE
fix(release): fallback root version when git-cliff does not advance it

### DIFF
--- a/scripts/changeset-version.sh
+++ b/scripts/changeset-version.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+CURRENT_VERSION="$(node -p "require('./package.json').version")"
+
 CLIFF_CONTEXT="$(pnpm exec git-cliff --unreleased --bump --context)"
 
 BUMPED_VERSION="$(
@@ -23,7 +25,22 @@ if [ -z "${BUMPED_VERSION}" ]; then
   exit 1
 fi
 
-pnpm version "${BUMPED_VERSION}" --no-git-tag-version
+PENDING_CHANGESET_COUNT="$(
+  find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' '
+)"
+
+if [ "${BUMPED_VERSION}" = "${CURRENT_VERSION}" ] && [ "${PENDING_CHANGESET_COUNT}" -gt 0 ]; then
+  BUMPED_VERSION="$(
+    node -e '
+      const [major, minor, patch] = process.argv[1].split(".").map(Number);
+      process.stdout.write(`${major}.${minor}.${patch + 1}`);
+    ' "${CURRENT_VERSION}"
+  )"
+fi
+
+if [ "${BUMPED_VERSION}" != "${CURRENT_VERSION}" ]; then
+  pnpm version "${BUMPED_VERSION}" --no-git-tag-version
+fi
 
 if [ ! -s NEXT-CHANGELOG-ENTRY.md ]; then
   pnpm exec git-cliff --unreleased --output NEXT-CHANGELOG-ENTRY.md --strip header --bump


### PR DESCRIPTION
## Summary
- add a root-version fallback in `scripts/changeset-version.sh`
- unblock `changesets/action` when pending changesets exist but `git-cliff --bump` returns the current root version
- recover the currently pending `@clinwise/release-scribe` release path from PR `#15`

## Root cause
The custom version script tried to run `pnpm version` with the unchanged root version `0.3.0`.
That happened because the repository had pending changesets, but the unreleased git-cliff bump still resolved to the current root version.

## Validation
- reproduced the failure from run `23044660593`
- verified the patched script in an isolated clone with `bash -x ./scripts/changeset-version.sh`
- confirmed the script now advances the root version to `0.3.1`
- confirmed `pnpm changeset version` completes and plans `@clinwise/release-scribe 0.1.0 -> 0.1.1`
